### PR TITLE
Remove warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.7
 Requires
-SpecialFunctions 0.7.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.7
 Requires
+SpecialFunctions 0.7.2

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -70,7 +70,7 @@ end
 
 function __init__()
     @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" begin
-        import SpecialFunctions
+        import .SpecialFunctions
 
         SpecialFunctions.erf(x::Float128) = Float128(ccall((:erfq, libquadmath), Cfloat128, (Cfloat128, ), x))
         SpecialFunctions.erfc(x::Float128) = Float128(ccall((:erfcq, libquadmath), Cfloat128, (Cfloat128, ), x))

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -70,7 +70,7 @@ end
 
 function __init__()
     @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" begin
-        using SpecialFunctions
+        import SpecialFunctions
 
         SpecialFunctions.erf(x::Float128) = Float128(ccall((:erfq, libquadmath), Cfloat128, (Cfloat128, ), x))
         SpecialFunctions.erfc(x::Float128) = Float128(ccall((:erfcq, libquadmath), Cfloat128, (Cfloat128, ), x))
@@ -322,4 +322,4 @@ end
 print(io::IO, b::Float128) = print(io, string(b))
 show(io::IO, b::Float128) = print(io, string(b))
 
-end # modeule Quadmath
+end # module Quadmath


### PR DESCRIPTION
```julia
┌ Warning: Package Quadmath does not have SpecialFunctions in its dependencies:
│ - If you have Quadmath checked out for development and have
│   added SpecialFunctions as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Quadmath
└ Loading SpecialFunctions into Quadmath from project dependency, future warnings for Quadmath are suppressed.
WARNING: using SpecialFunctions.erfc in module Quadmath conflicts with an existing identifier.
WARNING: using SpecialFunctions.erf in module Quadmath conflicts with an existing identifier.
```
