### PR TITLE
Pointer ABI for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 platform:
   - x64 # 64-bit
-#  - x86 # 32-big
+  - x86 # 32-big
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,5 +35,5 @@ test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
 
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,9 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
   - julia_version: nightly
 
 platform:
-  - x86 # 32-bit
   - x64 # 64-bit
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,8 @@ environment:
   - julia_version: nightly
 
 platform:
+  - x86 # 32-bit
   - x64 # 64-bit
-  - x86 # 32-big
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)
@@ -34,3 +34,6 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,8 @@ environment:
   - julia_version: nightly
 
 platform:
-  - x86 # 32-big
   - x64 # 64-bit
+#  - x86 # 32-big
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,3 +33,6 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ environment:
   - julia_version: nightly
 
 platform:
+  - x86 # 32-big
   - x64 # 64-bit
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,3 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
-
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "Quadmath"
+uuid = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
+
+[deps]
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+[extras]
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "SpecialFunctions"]
+

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ This is a Julia interface to libquadmath, providing a `Float128` type correspond
 
 ## Support
 
-Quadmath currently works on x86_64 Linux and macOS.
+Quadmath currently works on x86_64 Linux, macOS, and Windows.
 
 - It may require a new-ish version of gcc which supports `__float128` type.
 - It has not been tested on 32 bit Linux.
-- I have not had any luck getting it to work on Windows. It's probably something to do with the calling convention: if someone figures it out I would be very grateful.
 - It does not work on ARM due to the lack of libquadmath support for that platform.
 
 ## Installation

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7
+julia 1.0
 Requires

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -25,7 +25,7 @@ elseif Sys.isunix()
     const quadoplib = "libgcc_s.so.1"
     const libquadmath = "libquadmath.so.0"
 elseif Sys.iswindows()
-    if sizeof(Ptr{Cvoid}) == 8
+    if Sys.WORD_SIZE == 8
         const quadoplib = "libgcc_s_seh-1.dll"
     else
         const quadoplib = "libgcc_s_sjlj-1.dll"
@@ -85,61 +85,61 @@ function __init__()
           function SpecialFunctions.erf(x::Float128)
               r = Ref{Float128}()
               ccall((:erfq, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
               Float128(r[])
           end
           function SpecialFunctions.erfc(x::Float128)
               r = Ref{Float128}()
               ccall((:erfcq, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
               Float128(r[])
           end
           function SpecialFunctions.besselj0(x::Float128)
               r = Ref{Float128}()
               ccall((:j0q, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
               Float128(r[])
           end
           function SpecialFunctions.besselj1(x::Float128)
               r = Ref{Float128}()
               ccall((:j1q, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
               Float128(r[])
           end
           function SpecialFunctions.bessely0(x::Float128)
               r = Ref{Float128}()
               ccall((:y0q, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
               Float128(r[])
           end
           function SpecialFunctions.bessely1(x::Float128)
               r = Ref{Float128}()
               ccall((:y1q, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
               Float128(r[])
           end
           function SpecialFunctions.besselj(n::Cint, x::Float128)
               r = Ref{Float128}()
               ccall((:jnq, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Cint, Cfloat128), r, n, x)
+                    Cvoid, (Ptr{Cfloat128}, Cint, Ref{Cfloat128}), r, n, x)
               Float128(r[])
           end
           function SpecialFunctions.bessely(n::Cint, x::Float128)
               r = Ref{Float128}()
               ccall((:ynq, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Cint, Cfloat128), r, n, x)
+                    Cvoid, (Ptr{Cfloat128}, Cint, Ref{Cfloat128}), r, n, x)
               Float128(r[])
           end
           function SpecialFunctions.gamma(x::Float128)
               r = Ref{Float128}()
               ccall((:tgammaq, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
               Float128(r[])
           end
           function SpecialFunctions.lgamma(x::Float128)
               r = Ref{Float128}()
               ccall((:lgammaq, libquadmath),
-                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}), r, x)
               Float128(r[])
           end
 
@@ -260,7 +260,7 @@ for (op, func) in ((:+, :__addtf3), (:-, :__subtf3), (:*, :__multf3), (:/, :__di
             function ($op)(x::Float128, y::Float128)
                 r = Ref{Cfloat128}()
                 ccall((@_symsym($func),quadoplib),
-                      Cvoid, (Ptr{Cfloat128},Ref{Cfloat128},Ref{Cfloat128}),
+                      Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}),
                       r, x, y)
                 Float128(r[])
             end
@@ -277,7 +277,7 @@ end
 if Sys.iswindows()
     function (-)(x::Float128)
         r = Ref{Cfloat128}()
-        ccall((:__negtf2,quadoplib), Cvoid, (Ptr{Cfloat128}, Cfloat128,),
+        ccall((:__negtf2,quadoplib), Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}),
               r, x)
         Float128(r[])
     end
@@ -290,7 +290,7 @@ if Sys.iswindows()
     function (^)(x::Float128, y::Float128)
         r = Ref{Cfloat128}()
         ccall((:powq, libquadmath), Cvoid,
-              (Ptr{Cfloat128},Cfloat128,Cfloat128), r, x, y)
+              (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}), r, x, y)
         Float128(r[])
     end
 else
@@ -326,7 +326,7 @@ for (f,fc) in (:abs => :fabs,
         @eval function $f(x::Float128)
             r = Ref{Cfloat128}()
             ccall(($(string(fc,:q)), libquadmath),
-                           Cvoid, (Ptr{Cfloat128}, Cfloat128, ), r, x)
+                           Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}), r, x)
             Float128(r[])
         end
     else
@@ -339,27 +339,60 @@ end
 
 ## two argument
 for f in (:copysign, :hypot, )
-    @eval function $f(x::Float128, y::Float128)
-       Float128(ccall(($(string(f,:q)), libquadmath), Cfloat128, (Cfloat128, Cfloat128), x, y))
+    if Sys.iswindows()
+        @eval function $f(x::Float128, y::Float128)
+            r = Ref{Cloat128}()
+            ccall(($(string(f,:q)), libquadmath), Cvoid,
+                           (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}),
+                           r, x, y)
+            Float128(r[])
+        end
+    else
+        @eval function $f(x::Float128, y::Float128)
+            Float128(ccall(($(string(f,:q)), libquadmath), Cfloat128, (Cfloat128, Cfloat128), x, y))
+        end
     end
 end
 
 flipsign(x::Float128, y::Float128) = signbit(y) ? -x : x
 
-function atan(x::Float128, y::Float128)
-    Float128(ccall((:atan2q, libquadmath), Cfloat128, (Cfloat128, Cfloat128), x, y))
-end
+if Sys.iswindows()
+    function atan(x::Float128, y::Float128)
+        r = Ref{Cloat128}()
+        ccall((:atan2q, libquadmath), Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}), r, x, y)
+        Float128(r[])
+    end
 
 ## misc
-fma(x::Float128, y::Float128, z::Float128) =
-    Float128(ccall((:fmaq,libquadmath), Cfloat128, (Cfloat128, Cfloat128, Cfloat128), x, y, z))
+    function fma(x::Float128, y::Float128, z::Float128)
+        r = Ref{Cloat128}()
+        ccall((:fmaq,libquadmath), Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}), r, x, y, z)
+        Float128(r[])
+    end
 
-isnan(x::Float128) =
-    0 != ccall((:isnanq,libquadmath), Cint, (Cfloat128, ), x)
-isinf(x::Float128) =
-    0 != ccall((:isinfq,libquadmath), Cint, (Cfloat128, ), x)
-isfinite(x::Float128) =
-    0 != ccall((:finiteq,libquadmath), Cint, (Cfloat128, ), x)
+    isnan(x::Float128) =
+        0 != ccall((:isnanq,libquadmath), Cint, (Ref{Cfloat128}, ), x)
+    isinf(x::Float128) =
+        0 != ccall((:isinfq,libquadmath), Cint, (Ref{Cfloat128}, ), x)
+    isfinite(x::Float128) =
+        0 != ccall((:finiteq,libquadmath), Cint, (Ref{Cfloat128}, ), x)
+else
+    function atan(x::Float128, y::Float128)
+        Float128(ccall((:atan2q, libquadmath), Cfloat128, (Cfloat128, Cfloat128), x, y))
+    end
+
+## misc
+    fma(x::Float128, y::Float128, z::Float128) =
+        Float128(ccall((:fmaq,libquadmath), Cfloat128, (Cfloat128, Cfloat128, Cfloat128), x, y, z))
+
+    isnan(x::Float128) =
+        0 != ccall((:isnanq,libquadmath), Cint, (Cfloat128, ), x)
+    isinf(x::Float128) =
+        0 != ccall((:isinfq,libquadmath), Cint, (Cfloat128, ), x)
+    isfinite(x::Float128) =
+        0 != ccall((:finiteq,libquadmath), Cint, (Cfloat128, ), x)
+end
+
 isinteger(x::Float128) = isfinite(x) && x === trunc(x)
 
 signbit(x::Float128) = signbit(reinterpret(Int128, x))
@@ -373,7 +406,7 @@ if Sys.iswindows()
     function ldexp(x::Float128, n::Cint)
         r = Ref{Cfloat128}()
         ccall((:ldexpq, libquadmath),
-              Cvoid, (Ptr{Cfloat128}, Cfloat128, Cint), r, x, n)
+              Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}, Cint), r, x, n)
         Float128(r[])
     end
 else
@@ -390,7 +423,7 @@ if Sys.iswindows()
         r = Ref{Cfloat128}()
         ri = Ref{Cint}()
         ccall((:frexpq, libquadmath),
-              Cvoid, (Ptr{Cfloat128}, Cfloat128, Ptr{Cint}), r, x, ri)
+              Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}, Ptr{Cint}), r, x, ri)
         return Float128(r[]), Int(ri[])
     end
 else

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -89,6 +89,7 @@ convert(::Type{Float128}, x::Number) = Float128(x)
 const ComplexF128 = Complex{Float128}
 
 Base.cconvert(::Type{Cfloat128}, x::Float128) = x.data
+Base.cconvert(::Type{Ref{Cfloat128}}, x::Float128) = Ref{Cfloat128}(x.data)
 
 
 # reinterpret

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -64,11 +64,11 @@ macro ccall(expr)
         if ret_type == :Cfloat128
             quote
                 r = Ref{Cfloat128}()
-                ccall($fname, Cvoid, (Ref{Cfloat128}, $(esc(arg_types...)),), r, $(esc(arg_names...)))
+                ccall($fname, Cvoid, (Ref{Cfloat128}, $(esc.(arg_types)...),), r, $(esc.(arg_names)...))
                 r[]
             end                
         else
-            :(ccall($fname, $(esc(ret_type)), ($(esc(arg_types...)),), $(esc(arg_names...))))
+            :(ccall($fname, $(esc(ret_type)), ($(esc.(arg_types)...),), $(esc.(arg_names)...)))
         end
     end
 end

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -735,6 +735,16 @@ if _WIN_PTR_ABI
                     buf, lng + 1, "%.35Qe", x)
         return String(resize!(buf, lng))
     end
+elseif Sys.iswindows()
+    function string(x::Float128)
+        lng = 64
+        buf = Array{UInt8}(undef, lng + 1)
+        dummy = Int32(0) # for argument alignment on stack
+        lng = ccall((:quadmath_snprintf,libquadmath),
+                    Cint, (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Cint, Cfloat128...),
+                    buf, lng + 1, "%.35Qe", dummy, x)
+        return String(resize!(buf, lng))
+    end
 else
     function string(x::Float128)
         lng = 64

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -25,7 +25,11 @@ elseif Sys.isunix()
     const quadoplib = "libgcc_s.so.1"
     const libquadmath = "libquadmath.so.0"
 elseif Sys.iswindows()
-    const quadoplib = "libgcc_s_seh-1.dll"
+    if sizeof(Ptr{Cvoid}) == 8
+        const quadoplib = "libgcc_s_seh-1.dll"
+    else
+        const quadoplib = "libgcc_s_sjlj-1.dll"
+    end
     const libquadmath = "libquadmath-0.dll"
 end
 
@@ -75,8 +79,71 @@ end
 
 function __init__()
     @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" begin
-        import .SpecialFunctions
+      import .SpecialFunctions
 
+      if Sys.iswindows()
+          function SpecialFunctions.erf(x::Float128)
+              r = Ref{Float128}()
+              ccall((:erfq, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.erfc(x::Float128)
+              r = Ref{Float128}()
+              ccall((:erfcq, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.besselj0(x::Float128)
+              r = Ref{Float128}()
+              ccall((:j0q, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.besselj1(x::Float128)
+              r = Ref{Float128}()
+              ccall((:j1q, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.bessely0(x::Float128)
+              r = Ref{Float128}()
+              ccall((:y0q, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.bessely1(x::Float128)
+              r = Ref{Float128}()
+              ccall((:y1q, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.besselj(n::Cint, x::Float128)
+              r = Ref{Float128}()
+              ccall((:jnq, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Cint, Cfloat128), r, n, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.bessely(n::Cint, x::Float128)
+              r = Ref{Float128}()
+              ccall((:ynq, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Cint, Cfloat128), r, n, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.gamma(x::Float128)
+              r = Ref{Float128}()
+              ccall((:tgammaq, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+          function SpecialFunctions.lgamma(x::Float128)
+              r = Ref{Float128}()
+              ccall((:lgammaq, libquadmath),
+                    Cvoid, (Ptr{Cfloat128},Ref{Cfloat128}, ), r, x)
+              Float128(r[])
+          end
+
+      else
         SpecialFunctions.erf(x::Float128) = Float128(ccall((:erfq, libquadmath), Cfloat128, (Cfloat128, ), x))
         SpecialFunctions.erfc(x::Float128) = Float128(ccall((:erfcq, libquadmath), Cfloat128, (Cfloat128, ), x))
 
@@ -89,6 +156,7 @@ function __init__()
 
         SpecialFunctions.gamma(x::Float128) = Float128(ccall((:tgammaq, libquadmath), Cfloat128, (Cfloat128, ), x))
         SpecialFunctions.lgamma(x::Float128) = Float128(ccall((:lgammaq, libquadmath), Cfloat128, (Cfloat128, ), x))
+      end
     end
 end
 

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -327,6 +327,14 @@ if _WIN_PTR_ABI
               (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}), r, x, y)
         Float128(r[])
     end
+elseif Sys.iswindows()
+    function (^)(x::Float128, y::Float128)
+        r = Ref{Cfloat128}()
+        p = PadPtr(r)
+        ccall((:powq, libquadmath), Cvoid,
+              (PF128, Cfloat128, Cfloat128), p, x, y)
+        Float128(r[])
+    end
 else
     (^)(x::Float128, y::Float128) =
         Float128(ccall((:powq, libquadmath), Cfloat128,
@@ -391,7 +399,7 @@ end
 for f in (:copysign, :hypot, )
     if _WIN_PTR_ABI
         @eval function $f(x::Float128, y::Float128)
-            r = Ref{Cloat128}()
+            r = Ref{Cfloat128}()
             ccall(($(string(f,:q)), libquadmath), Cvoid,
                            (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}),
                            r, x, y)
@@ -399,7 +407,7 @@ for f in (:copysign, :hypot, )
         end
     elseif Sys.iswindows()
         @eval function $f(x::Float128, y::Float128)
-            r = Ref{Cloat128}()
+            r = Ref{Cfloat128}()
             p = PadPtr(r)
             ccall(($(string(f,:q)), libquadmath), Cvoid,
                            (PF128, Cfloat128, Cfloat128),
@@ -417,14 +425,14 @@ flipsign(x::Float128, y::Float128) = signbit(y) ? -x : x
 
 if _WIN_PTR_ABI
     function atan(x::Float128, y::Float128)
-        r = Ref{Cloat128}()
+        r = Ref{Cfloat128}()
         ccall((:atan2q, libquadmath), Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}), r, x, y)
         Float128(r[])
     end
 
 ## misc
     function fma(x::Float128, y::Float128, z::Float128)
-        r = Ref{Cloat128}()
+        r = Ref{Cfloat128}()
         ccall((:fmaq,libquadmath), Cvoid, (Ptr{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}, Ref{Cfloat128}), r, x, y, z)
         Float128(r[])
     end
@@ -438,7 +446,7 @@ if _WIN_PTR_ABI
 else
     if Sys.iswindows()
         function atan(x::Float128, y::Float128)
-            r = Ref{Cloat128}()
+            r = Ref{Cfloat128}()
             p = PadPtr(r)
             ccall((:atan2q, libquadmath), Cvoid,
                   (PF128, Cfloat128, Cfloat128), p, x, y)
@@ -446,7 +454,7 @@ else
         end
 
         function fma(x::Float128, y::Float128, z::Float128)
-            r = Ref{Cloat128}()
+            r = Ref{Cfloat128}()
             p = PadPtr(r)
             ccall((:fmaq,libquadmath), Cvoid,
                   (PF128, Cfloat128, Cfloat128, Cfloat128), p, x, y, z)

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -58,9 +58,6 @@ macro ccall(expr)
     if Sys.isunix()
         :(ccall($fname, $(esc(ret_type)), ($(esc.(arg_types)...),), $(esc.(arg_names)...)))
     else
-        arg_types = [T == :Cfloat128 ? :(Ref{Cfloat128}) :
-                     T == :(Cfloat128...) ? :(Ref{Cfloat128}...) :
-                     T for T in arg_types]        
         if ret_type == :Cfloat128
             quote
                 r = Ref{Cfloat128}()

--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -1,0 +1,55 @@
+import SpecialFunctions
+
+for (f, sym) in ((:erf, :erfq), (:erfc, :erfcq),
+                 (:besselj0, :j0q), (:besselj1, :j1q),
+                 (:bessely0, :y0q), (:bessely1, :y1q),
+                 (:gamma, :tgammaq), (:lgamma, :lgammaq)
+                 )
+    @eval import SpecialFunctions: $f
+    if _WIN_PTR_ABI
+        @eval function $f(x::Float128)
+            r = Ref{Cfloat128}()
+            ccall(($(string(sym)), libquadmath),
+                  Cvoid, (Ptr{Cfloat128}, Cfloat128, ), r, x)
+            Float128(r[])
+        end
+    elseif Sys.iswindows()
+        @eval function $f(x::Float128)
+            r = Ref{Cfloat128}()
+            p = PadPtr(r)
+            ccall(($(string(sym)), libquadmath),
+                  Cvoid, (PF128, Cfloat128, ), p, x)
+            Float128(r[])
+        end
+    else
+        @eval function $f(x::Float128)
+            Float128(ccall(($(string(sym)), libquadmath),
+                           Cfloat128, (Cfloat128, ), x))
+        end
+    end
+end
+for (f, sym) in ((:besselj, :jnq), (:bessely, :ynq))
+    @eval import SpecialFunctions: $f
+    if _WIN_PTR_ABI
+        @eval function $f(n::Int, x::Float128)
+            r = Ref{Cfloat128}()
+            ccall(($(string(sym)), libquadmath),
+                  Cvoid, (Ptr{Cfloat128}, Cint, Cfloat128, ), r, n, x)
+            Float128(r[])
+        end
+    elseif Sys.iswindows()
+        @eval function $f(n::Int, x::Float128)
+            r = Ref{Cfloat128}()
+            dummy = Int32(0) # for alignment
+            ccall(($(string(sym)), libquadmath),
+                  Cvoid, (Ptr{Cfloat128}, Cint, Cint, Cint, Cfloat128, ),
+                  r, n, dummy, dummy, x)
+            Float128(r[])
+        end
+    else
+        @eval function $f(n::Int, x::Float128)
+            Float128(ccall(($(string(sym)), libquadmath),
+                           Cfloat128, (Cint, Cfloat128), n, x))
+        end
+    end
+end

--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -1,55 +1,26 @@
 import SpecialFunctions
 
-for (f, sym) in ((:erf, :erfq), (:erfc, :erfcq),
-                 (:besselj0, :j0q), (:besselj1, :j1q),
-                 (:bessely0, :y0q), (:bessely1, :y1q),
-                 (:gamma, :tgammaq), (:lgamma, :lgammaq)
-                 )
-    @eval import SpecialFunctions: $f
-    if _WIN_PTR_ABI
-        @eval function $f(x::Float128)
-            r = Ref{Cfloat128}()
-            ccall(($(string(sym)), libquadmath),
-                  Cvoid, (Ptr{Cfloat128}, Cfloat128, ), r, x)
-            Float128(r[])
-        end
-    elseif Sys.iswindows()
-        @eval function $f(x::Float128)
-            r = Ref{Cfloat128}()
-            p = PadPtr(r)
-            ccall(($(string(sym)), libquadmath),
-                  Cvoid, (PF128, Cfloat128, ), p, x)
-            Float128(r[])
-        end
-    else
-        @eval function $f(x::Float128)
-            Float128(ccall(($(string(sym)), libquadmath),
-                           Cfloat128, (Cfloat128, ), x))
-        end
-    end
-end
-for (f, sym) in ((:besselj, :jnq), (:bessely, :ynq))
-    @eval import SpecialFunctions: $f
-    if _WIN_PTR_ABI
-        @eval function $f(n::Int, x::Float128)
-            r = Ref{Cfloat128}()
-            ccall(($(string(sym)), libquadmath),
-                  Cvoid, (Ptr{Cfloat128}, Cint, Cfloat128, ), r, n, x)
-            Float128(r[])
-        end
-    elseif Sys.iswindows()
-        @eval function $f(n::Int, x::Float128)
-            r = Ref{Cfloat128}()
-            dummy = Int32(0) # for alignment
-            ccall(($(string(sym)), libquadmath),
-                  Cvoid, (Ptr{Cfloat128}, Cint, Cint, Cint, Cfloat128, ),
-                  r, n, dummy, dummy, x)
-            Float128(r[])
-        end
-    else
-        @eval function $f(n::Int, x::Float128)
-            Float128(ccall(($(string(sym)), libquadmath),
-                           Cfloat128, (Cint, Cfloat128), n, x))
-        end
-    end
-end
+SpecialFunctions.erf(x::Float128) =
+    Float128(@ccall(libquadmath.erfq(x::Cfloat128)::Cfloat128))
+SpecialFunctions.erfc(x::Float128) =
+    Float128(@ccall(libquadmath.erfcq(x::Cfloat128)::Cfloat128))
+
+SpecialFunctions.besselj0(x::Float128) =
+    Float128(@ccall(libquadmath.j0q(x::Cfloat128)::Cfloat128))
+SpecialFunctions.besselj1(x::Float128) =
+    Float128(@ccall(libquadmath.j1q(x::Cfloat128)::Cfloat128))
+
+SpecialFunctions.bessely0(x::Float128) =
+    Float128(@ccall(libquadmath.y0q(x::Cfloat128)::Cfloat128))
+SpecialFunctions.bessely1(x::Float128) =
+    Float128(@ccall(libquadmath.y1q(x::Cfloat128)::Cfloat128))
+
+SpecialFunctions.besselj(n::Integer, x::Float128) =
+    Float128(@ccall(libquadmath.jnq(n::Cint, x::Cfloat128)::Cfloat128))
+SpecialFunctions.bessely(n::Integer, x::Float128) =
+    Float128(@ccall(libquadmath.ynq(n::Cint, x::Cfloat128)::Cfloat128))
+
+SpecialFunctions.gamma(x::Float128) =
+    Float128(@ccall(libquadmath.tgammaq(x::Cfloat128)::Cfloat128))
+SpecialFunctions.lgamma(x::Float128) =
+    Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,14 @@ end
     @test fma(x,x,Float128(-1.0)) ≈ Float128(1)
 end
 
+@testset "string conversion" begin
+    s = string(Float128(3.0))
+    p = r"3\.0+e\+0+"
+    m = match(p, s)
+    @test (m != nothing) && (m.match == s)
+    @test parse(Float128,"3.0") == Float128(3.0)
+end
+
 if !Sys.iswindows() || (Sys.WORD_SIZE == 64)
     include("specfun.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,15 @@
 using Test
 using Quadmath
 
+@testset "fp decomp" begin
+    y = Float128(2.0)
+    x,n = frexp(y)
+    @test x == Float128(0.5)
+    @test n == 2
+    z = ldexp(Float128(0.5), 2)
+    @test z == y
+end
+
 @testset "conversion $T" for T in (Float64, Int32, Int64, BigFloat, BigInt)
     @test Float128(T(1)) + Float128(T(2)) == Float128(T(3))
     @test Float128(T(1)) + Float128(T(2)) <= Float128(T(3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,3 +60,19 @@ end
     fpart, ipart = modf(x) .+ modf(y)
     @test x+y == ipart+fpart
 end
+
+@testset "transcendental etc. calls" begin
+    # at least enough to cover all the wrapping code
+    x = sqrt(Float128(2.0))
+    xd = Float64(x)
+    @test (x^Float128(4.0)) ≈ Float128(4.0)
+    @test exp(x) ≈ exp(xd)
+    @test abs(x) == x
+    @test hypot(Float128(3),Float128(4)) == Float128(5)
+    @test atan(x,x) ≈ Float128(pi) / 4
+    @test fma(x,x,Float128(-1.0)) ≈ Float128(1)
+end
+
+if !Sys.iswindows() || (Sys.WORD_SIZE == 64)
+    include("specfun.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,4 @@ end
     @test parse(Float128,"3.0") == Float128(3.0)
 end
 
-if !Sys.iswindows() || (Sys.WORD_SIZE == 64)
-    include("specfun.jl")
-end
+include("specfun.jl")

--- a/test/specfun.jl
+++ b/test/specfun.jl
@@ -1,0 +1,15 @@
+using SpecialFunctions
+
+@testset "special functions" begin
+    # The intention here is not to check the accuracy of the libraries,
+    # rather the sanity of library calls:
+    piq = Float128(pi)
+    halfq = Float128(0.5)
+    @test gamma(halfq) ≈ sqrt(piq)
+    for func in (erf, erfc, besselj0, besselj1, bessely0, bessely1, lgamma)
+        @test func(halfq) ≈ func(0.5)
+    end
+    for func in (bessely, besselj)
+        @test func(3,halfq) ≈ func(3,0.5)
+    end
+end


### PR DESCRIPTION
The Windows (msys) libraries apparently use pointer ABI for Float128. This is an attempt to accommodate them.