### PR TITLE
bugfix: [u]int128 conversion for huge values

### DIFF
--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -158,9 +158,9 @@ function Float128(x::UInt128)
     if n <= 113
         y = ((x % UInt128) << (113-n)) & significand_mask(Float128)
     else
-        y = ((x >> (n-114)) % UInt128) & 0x001_ffff_ffff_ffff_ffff_ffff_ffff_ffff # keep 1 extra bit
+        y = ((x >> (n-114)) % UInt128) & 0x0001_ffff_ffff_ffff_ffff_ffff_ffff_ffff # keep 1 extra bit
         y = (y+1)>>1 # round, ties up (extra leading bit in case of next exponent)
-        y &= ~UInt64(trailing_zeros(x) == (n-114)) # fix last bit to round to even
+        y &= ~UInt128(trailing_zeros(x) == (n-114)) # fix last bit to round to even
     end
     d = ((n+16382) % UInt128) << 112
     # reinterpret(Float128, d + y)
@@ -184,7 +184,7 @@ function Float128(x::Int128)
     else
         y = ((x >> (n-114)) % UInt128) & 0x0001_ffff_ffff_ffff_ffff_ffff_ffff_ffff # keep 1 extra bit
         y = (y+1)>>1 # round, ties up (extra leading bit in case of next exponent)
-        y &= ~UInt64(trailing_zeros(x) == (n-114)) # fix last bit to round to even
+        y &= ~UInt128(trailing_zeros(x) == (n-114)) # fix last bit to round to even
     end
     d = ((n+16382) % UInt128) << 112
     # reinterpret(Float128, s | d + y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,13 @@ end
     else
         @test T(Float128(T(1)) + Float128(T(2))) == T(3)
     end
+    if isbitstype(T) && T <: Integer
+        nb = 8*sizeof(T) - 5
+        x = T(9) << nb
+        xf = Float128(9) * 2.0^nb
+        @test Float128(x) == xf
+        @test T(xf) == x
+    end
 end
 
 @testset "conversion $T exceptions" for T in (Int32, Int64, UInt32, UInt64)


### PR DESCRIPTION
This change corrects an oversight in the translation of code from Base (for Float64).