### PR TITLE
methods needed for [s]printf macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [extras]
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [targets]
-test = ["Test", "SpecialFunctions"]
-
+test = ["Test", "SpecialFunctions", "Printf"]

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -549,4 +549,6 @@ end
 print(io::IO, b::Float128) = print(io, string(b))
 show(io::IO, b::Float128) = print(io, string(b))
 
+include("printf.jl")
+
 end # module Quadmath

--- a/src/printf.jl
+++ b/src/printf.jl
@@ -1,11 +1,21 @@
 import Base.Printf: ini_dec, fix_dec, ini_hex, ini_HEX
 
+if VERSION < v"1.1"
+using Base.Grisu: DIGITSs
+fix_dec(out, d::Float128, flags::String, width::Int, precision::Int, c::Char) = fp128_printf(out, d, flags, width, precision, c, DIGITSs[Threads.threadid()])
+ini_dec(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char) = fp128_printf(out, d, flags, width, precision, c, DIGITSs[Threads.threadid()])
+ini_hex(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char) = fp128_printf(out, d, flags, width, precision, c, DIGITSs[Threads.threadid()])
+ini_HEX(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char) = fp128_printf(out, d, flags, width, precision, c, DIGITSs[Threads.threadid()])
+ini_hex(out, d::Float128, flags::String, width::Int, precision::Int, c::Char) = fp128_printf(out, d, flags, width, precision, c, DIGITSs[Threads.threadid()])
+ini_HEX(out, d::Float128, flags::String, width::Int, precision::Int, c::Char) = fp128_printf(out, d, flags, width, precision, c, DIGITSs[Threads.threadid()])
+else
 fix_dec(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
 ini_dec(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
 ini_hex(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
 ini_HEX(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
 ini_hex(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
 ini_HEX(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
+end
 
 function fp128_printf(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits)
     fmt_len = sizeof(flags)+4
@@ -35,9 +45,6 @@ function fp128_printf(out, d::Float128, flags::String, width::Int, precision::In
     @assert length(printf_fmt) == fmt_len
     bufsiz = length(digits)
     lng = @ccall(libquadmath.quadmath_snprintf(digits::Ptr{UInt8}, bufsiz::Csize_t, printf_fmt::Ptr{UInt8}, d::(Cfloat128...))::Cint)
-#    lng = ccall((:mpfr_snprintf,:libmpfr), Int32,
-#                (Ptr{UInt8}, Culong, Ptr{UInt8}, Ref{Float}...),
-#                digits, bufsiz, printf_fmt, d)
     lng > 0 || error("invalid printf formatting for Float128")
     unsafe_write(out, pointer(digits), min(lng, bufsiz-1))
     return (false, ())

--- a/src/printf.jl
+++ b/src/printf.jl
@@ -1,0 +1,44 @@
+import Base.Printf: ini_dec, fix_dec, ini_hex, ini_HEX
+
+fix_dec(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
+ini_dec(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
+ini_hex(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
+ini_HEX(out, d::Float128, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
+ini_hex(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
+ini_HEX(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits) = fp128_printf(out, d, flags, width, precision, c, digits)
+
+function fp128_printf(out, d::Float128, flags::String, width::Int, precision::Int, c::Char, digits)
+    fmt_len = sizeof(flags)+4
+    if width > 0
+        fmt_len += ndigits(width)
+    end
+    if precision >= 0
+        fmt_len += ndigits(precision)+1
+    end
+    fmt = IOBuffer(maxsize=fmt_len)
+    print(fmt, '%')
+    print(fmt, flags)
+    if width > 0
+        print(fmt, width)
+    end
+    if precision == 0
+        print(fmt, '.')
+        print(fmt, '0')
+    elseif precision > 0
+        print(fmt, '.')
+        print(fmt, precision)
+    end
+    print(fmt, 'Q')
+    print(fmt, c)
+    write(fmt, UInt8(0))
+    printf_fmt = take!(fmt)
+    @assert length(printf_fmt) == fmt_len
+    bufsiz = length(digits)
+    lng = @ccall(libquadmath.quadmath_snprintf(digits::Ptr{UInt8}, bufsiz::Csize_t, printf_fmt::Ptr{UInt8}, d::(Cfloat128...))::Cint)
+#    lng = ccall((:mpfr_snprintf,:libmpfr), Int32,
+#                (Ptr{UInt8}, Culong, Ptr{UInt8}, Ref{Float}...),
+#                digits, bufsiz, printf_fmt, d)
+    lng > 0 || error("invalid printf formatting for Float128")
+    unsafe_write(out, pointer(digits), min(lng, bufsiz-1))
+    return (false, ())
+end

--- a/test/printf.jl
+++ b/test/printf.jl
@@ -1,0 +1,48 @@
+using Printf
+
+@testset "printf" begin
+    for (fmt, val) in (("%7.2f", "   1.23"),
+                   ("%-7.2f", "1.23   "),
+                   ("%07.2f", "0001.23"),
+                   ("%.0f", "1"),
+                   ("%#.0f", "1."),
+                   ("%.4e", "1.2345e+00"),
+                   ("%.4E", "1.2345E+00"),
+                   ("%.2a", "0x1.3cp+0"),
+                   ("%.2A", "0X1.3CP+0")),
+        num in (Float128(1.2345),)
+        @test @eval(@sprintf($fmt, $num) == $val)
+    end
+    @test (@sprintf "%f" Float128(Inf)) == "Inf"
+    @test (@sprintf "%f" Float128(NaN)) == "NaN"
+    @test (@sprintf "%.0e" Float128(3e142)) == "3e+142"
+    @test (@sprintf "%#.0e" Float128(3e142)) == "3.e+142"
+
+    @test (@sprintf "%.0e" Float128(big"3e1042")) == "3e+1042"
+
+    for (val, res) in ((Float128(12345678.), "1.23457e+07"),
+                   (Float128(1234567.8), "1.23457e+06"),
+                   (Float128(123456.78), "123457"),
+                   (Float128(12345.678), "12345.7"))
+        @test (@sprintf("%.6g", val) == res)
+    end
+
+    for (fmt, val) in (("%10.5g", "     123.4"),
+                       ("%+10.5g", "    +123.4"),
+                       ("% 10.5g","     123.4"),
+                       ("%#10.5g", "    123.40"),
+                       ("%-10.5g", "123.4     "),
+                       ("%-+10.5g", "+123.4    "),
+                       ("%010.5g", "00000123.4")),
+        num in (Float128(123.4),)
+        @test @eval(@sprintf($fmt, $num) == $val)
+    end
+    @test( @sprintf( "%10.5g", Float128(-123.4) ) == "    -123.4")
+    @test( @sprintf( "%010.5g", Float128(-123.4) ) == "-0000123.4")
+    @test( @sprintf( "%.6g", Float128(12340000.0) ) == "1.234e+07")
+    @test( @sprintf( "%#.6g", Float128(12340000.0)) == "1.23400e+07")
+
+    @test (@sprintf "%a" Float128(1.5)) == "0x1.8p+0"
+
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,3 +104,5 @@ end
 end
 
 include("specfun.jl")
+
+include("printf.jl")


### PR DESCRIPTION
Basically copied from the approach used for BigFloat in Base.