### PR TITLE
Return SpecialFunctions to Requires management, w/o warnings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ julia = "1.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [extras]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -1,4 +1,5 @@
 module Quadmath
+using Requires
 
 export Float128, ComplexF128, Inf128
 
@@ -104,6 +105,12 @@ reinterpret(::Type{Int128}, x::Float128) =
     reinterpret(Int128, reinterpret(UInt128, x))
 reinterpret(::Type{Float128}, x::Int128) =
     reinterpret(Float128, reinterpret(UInt128, x))
+
+function __init__()
+    @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" begin
+        include("specfun.jl")
+    end
+end
 
 
 sign_mask(::Type{Float128}) =        0x8000_0000_0000_0000_0000_0000_0000_0000
@@ -579,7 +586,6 @@ end
 print(io::IO, b::Float128) = print(io, string(b))
 show(io::IO, b::Float128) = print(io, string(b))
 
-include("specfun.jl")
 include("printf.jl")
 
 end # module Quadmath

--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -1,26 +1,28 @@
-import SpecialFunctions
+import .SpecialFunctions
+import .SpecialFunctions: erf, erfc, besselj0, besselj1, bessely0, bessely1,
+    besselj, bessely, gamma, lgamma
 
-SpecialFunctions.erf(x::Float128) =
+erf(x::Float128) =
     Float128(@ccall(libquadmath.erfq(x::Cfloat128)::Cfloat128))
-SpecialFunctions.erfc(x::Float128) =
+erfc(x::Float128) =
     Float128(@ccall(libquadmath.erfcq(x::Cfloat128)::Cfloat128))
 
-SpecialFunctions.besselj0(x::Float128) =
+besselj0(x::Float128) =
     Float128(@ccall(libquadmath.j0q(x::Cfloat128)::Cfloat128))
-SpecialFunctions.besselj1(x::Float128) =
+besselj1(x::Float128) =
     Float128(@ccall(libquadmath.j1q(x::Cfloat128)::Cfloat128))
 
-SpecialFunctions.bessely0(x::Float128) =
+bessely0(x::Float128) =
     Float128(@ccall(libquadmath.y0q(x::Cfloat128)::Cfloat128))
-SpecialFunctions.bessely1(x::Float128) =
+bessely1(x::Float128) =
     Float128(@ccall(libquadmath.y1q(x::Cfloat128)::Cfloat128))
 
-SpecialFunctions.besselj(n::Integer, x::Float128) =
+besselj(n::Integer, x::Float128) =
     Float128(@ccall(libquadmath.jnq(n::Cint, x::Cfloat128)::Cfloat128))
-SpecialFunctions.bessely(n::Integer, x::Float128) =
+bessely(n::Integer, x::Float128) =
     Float128(@ccall(libquadmath.ynq(n::Cint, x::Cfloat128)::Cfloat128))
 
-SpecialFunctions.gamma(x::Float128) =
+gamma(x::Float128) =
     Float128(@ccall(libquadmath.tgammaq(x::Cfloat128)::Cfloat128))
-SpecialFunctions.lgamma(x::Float128) =
+lgamma(x::Float128) =
     Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
-using Quadmath, SpecialFunctions
-using Random, Test
+using Test, Random
+using Quadmath
 
 @testset "fp decomp" begin
     y = Float128(2.0)

--- a/test/specfun.jl
+++ b/test/specfun.jl
@@ -1,12 +1,12 @@
+using SpecialFunctions
+
 @testset "special functions" begin
     # The intention here is not to check the accuracy of the libraries,
     # rather the sanity of library calls:
     piq = Float128(pi)
     halfq = Float128(0.5)
     @test gamma(halfq) ≈ sqrt(piq)
-    for func in (erf, erfc, 
-                 besselj0, besselj1, 
-                 bessely0, bessely1, lgamma)
+    for func in (erf, erfc, besselj0, besselj1, bessely0, bessely1, lgamma)
         @test func(halfq) ≈ func(0.5)
     end
     for func in (bessely, besselj)


### PR DESCRIPTION
This is intended to accommodate issue #37 by returning to conditional overloading of SpecialFunctions methods, but using "dot" syntax to avoid the warnings which presumably motivated #35.