### PR TITLE
clean up irrational conversions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quadmath"
 uuid = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
-version = "0.5.1"
+version = "0.5.2-DEV"
 
 [compat]
 julia = "1.0"

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -446,7 +446,8 @@ function nextfloat(f::Float128, d::Integer)
 end
 
 Float128(::Irrational{:π}) =  reinterpret(Float128, 0x4000921fb54442d18469898cc51701b8)
-Float128(::Irrational{:e}) =  reinterpret(Float128, 0x40005bf0a8b1457695355fb8ac404e7a)
+Float128(::Irrational{:ℯ}) =  reinterpret(Float128, 0x40005bf0a8b1457695355fb8ac404e7a)
+Float128(x::Irrational{T}) where {T} = Float128(BigFloat(x))
 
 import Base.MPFR
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,6 +173,13 @@ end
     @test parse(Float128,"3.0") == Float128(3.0)
 end
 
+@testset "irrationals" begin
+    tiny = 2eps(Float128(1))
+    @test abs(cos(Float128(pi)) + 1) < tiny
+    @test abs(log(Float128(ℯ)) - 1) < tiny
+    @test abs((2*Float128(MathConstants.golden) - 1)^2 - 5) < 5 * tiny
+end
+
 include("specfun.jl")
 
 include("printf.jl")


### PR DESCRIPTION
We were using the wrong (obsolete?) symbol for `e`.