### PR TITLE
Use libgcc on apple m1

### DIFF
--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -20,8 +20,11 @@ import Base: (*), +, -, /,  <, <=, ==, ^, convert,
 
 using Random
 
-if Sys.isapple()
+if Sys.isapple() && Sys.ARCH == :x86_64
     const quadoplib = "libquadmath.0"
+    const libquadmath = "libquadmath.0"
+elseif Sys.isapple() && Sys.ARCH == :aarch64
+    const quadoplib = "libgcc_s.1.1.dylib"
     const libquadmath = "libquadmath.0"
 elseif Sys.isunix()
     const quadoplib = "libgcc_s.so.1"


### PR DESCRIPTION
The symbols used are inside libgcc instead of in libquadmath as in intel.
Should fix https://github.com/JuliaMath/Quadmath.jl/issues/54