### PR TITLE
Added wrapper for Base.rem (maps to remainderq) and also Base.Integer…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quadmath"
 uuid = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -356,7 +356,7 @@ end
 @assume_effects :foldable atan(x::Float128, y::Float128) =
     Float128(@ccall(libquadmath.atan2q(x::Cfloat128, y::Cfloat128)::Cfloat128))
 
-Base.Integer(x::Float128) = Int64(x)
+Base.Integer(x::Float128) = Int(x)
 @assume_effects :foldable Base.rem(x::Float128, y::Float128) =
     Float128(@ccall(libquadmath.remainderq(x::Cfloat128, y::Cfloat128)::Cfloat128))
 

--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -355,6 +355,11 @@ end
     Float128(@ccall(libquadmath.hypotq(x::Cfloat128, y::Cfloat128)::Cfloat128))
 @assume_effects :foldable atan(x::Float128, y::Float128) =
     Float128(@ccall(libquadmath.atan2q(x::Cfloat128, y::Cfloat128)::Cfloat128))
+
+Base.Integer(x::Float128) = Int64(x)
+@assume_effects :foldable Base.rem(x::Float128, y::Float128) =
+    Float128(@ccall(libquadmath.remainderq(x::Cfloat128, y::Cfloat128)::Cfloat128))
+
 sincos(x::Float128) = (sin(x), cos(x))
 
 ## misc

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,7 @@ end
     m = maxintfloat(Float128)
     @test m+one(Float128) == m
     @test m-one(Float128) != m
+    @test rem(Float128(3//2), Float128(1//2)) == 0.0
 end
 
 function hist(X, n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,6 +224,7 @@ end
     @test !(1//3 < fnan)
     @test !(1//3 == fnan)
     @test !(1//3 > fnan)
+    @test [Float128(-10//1):Float128(1//10):Float128(0//1);] isa Any
 end
 
 @testset "ambiguities" begin


### PR DESCRIPTION
…(x::Float128) = Int64(x) and a single test case that uses both. Fixes #64