### PR TITLE
add logabsgamma

### DIFF
--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -28,6 +28,7 @@ lgamma(x::Float128) =
     Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))
 
 function logabsgamma(x::Float128)
-    sign = !isfinite(x) || x >= 0 || !iszero(mod(ceil(x), 2)) ? 1 : -1
-    return lgamma(x), sign
+    result = lgamma(x)
+    sign = !isfinite(result) || x >= 0 || !iszero(mod(ceil(x), 2)) ? 1 : -1
+    return result, sign
 end

--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -1,6 +1,6 @@
 import .SpecialFunctions
 import .SpecialFunctions: erf, erfc, besselj0, besselj1, bessely0, bessely1,
-    besselj, bessely, gamma, lgamma
+    besselj, bessely, gamma, lgamma, logabsgamma
 
 erf(x::Float128) =
     Float128(@ccall(libquadmath.erfq(x::Cfloat128)::Cfloat128))
@@ -26,3 +26,8 @@ gamma(x::Float128) =
     Float128(@ccall(libquadmath.tgammaq(x::Cfloat128)::Cfloat128))
 lgamma(x::Float128) =
     Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))
+
+function logabsgamma(x::Float128)
+    sign = x >= 0 ? 1 : 2*mod(ceil(Int64,x),2)-1
+    return lgamma(x), sign
+end

--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -1,6 +1,6 @@
 import .SpecialFunctions
 import .SpecialFunctions: erf, erfc, besselj0, besselj1, bessely0, bessely1,
-    besselj, bessely, gamma, lgamma, logabsgamma
+    besselj, bessely, gamma, logabsgamma
 
 erf(x::Float128) =
     Float128(@ccall(libquadmath.erfq(x::Cfloat128)::Cfloat128))
@@ -24,11 +24,9 @@ bessely(n::Integer, x::Float128) =
 
 gamma(x::Float128) =
     Float128(@ccall(libquadmath.tgammaq(x::Cfloat128)::Cfloat128))
-lgamma(x::Float128) =
-    Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))
 
 function logabsgamma(x::Float128)
-    result = lgamma(x)
+    result = Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))
     sign = !isfinite(result) || x >= 0 || !iszero(mod(ceil(x), 2)) ? 1 : -1
     return result, sign
 end

--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -28,10 +28,6 @@ lgamma(x::Float128) =
     Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))
 
 function logabsgamma(x::Float128)
-    if isfinite(x)
-      sign = x >= 0 ? 1 : 2*mod(ceil(Int64,x),2)-1
-    else
-      sign = 1
-    end
+    sign = !isfinite(x) || x >= 0 || !iszero(mod(ceil(x), 2)) ? 1 : -1
     return lgamma(x), sign
 end

--- a/src/specfun.jl
+++ b/src/specfun.jl
@@ -28,6 +28,10 @@ lgamma(x::Float128) =
     Float128(@ccall(libquadmath.lgammaq(x::Cfloat128)::Cfloat128))
 
 function logabsgamma(x::Float128)
-    sign = x >= 0 ? 1 : 2*mod(ceil(Int64,x),2)-1
+    if isfinite(x)
+      sign = x >= 0 ? 1 : 2*mod(ceil(Int64,x),2)-1
+    else
+      sign = 1
+    end
     return lgamma(x), sign
 end

--- a/test/specfun.jl
+++ b/test/specfun.jl
@@ -6,10 +6,13 @@ using SpecialFunctions
     piq = Float128(pi)
     halfq = Float128(0.5)
     @test gamma(halfq) ≈ sqrt(piq)
-    for func in (erf, erfc, besselj0, besselj1, bessely0, bessely1, lgamma)
+    for func in (erf, erfc, besselj0, besselj1, bessely0, bessely1, loggamma)
         @test func(halfq) ≈ func(0.5)
     end
     for func in (bessely, besselj)
         @test func(3,halfq) ≈ func(3,0.5)
     end
+    @test gamma(Float128(2),3) ≈ gamma(2,3)
+    @test all(logabsgamma(Float128(-0.5)) .≈ logabsgamma(-0.5))
+    @test all(logabsgamma(Float128(-1.5)) .≈ logabsgamma(-1.5))
 end


### PR DESCRIPTION
Fixes #71

I've realized that it is not necessary to define `loggamma`, as the one from `SpecialFunctions` works when we provide a `logabsgamma`.