### PR TITLE
add definitions for missing base/float.jl methods

### DIFF
--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -6,7 +6,9 @@ export Float128, ComplexF128, Inf128
 
 import Base: (*), +, -, /,  <, <=, ==, ^, convert,
           reinterpret, sign_mask, exponent_mask, exponent_one, exponent_half,
-          significand_mask, exponent, significand,
+          significand_mask, significand_bits, exponent_bits, exponent_bias,
+          exponent_max, exponent_raw_max, uinttype, inttype, floattype,
+          exponent, significand,
           promote_rule, widen,
           string, print, show, parse,
           acos, acosh, asin, asinh, atan, atanh, cosh, cos, sincos,
@@ -127,7 +129,18 @@ exponent_one(::Type{Float128}) =     0x3fff_0000_0000_0000_0000_0000_0000_0000
 exponent_half(::Type{Float128}) =    0x3ffe_0000_0000_0000_0000_0000_0000_0000
 significand_mask(::Type{Float128}) = 0x0000_ffff_ffff_ffff_ffff_ffff_ffff_ffff
 
-fpinttype(::Type{Float128}) = UInt128
+significand_bits(::Type{Float128}) = 112
+exponent_bits(::Type{Float128}) = 15
+exponent_bias(::Type{Float128}) = 16383
+exponent_max(::Type{Float128}) = 16383
+exponent_raw_max(::Type{Float128}) = 32767
+
+uinttype(::Type{Float128}) = UInt128
+inttype(::Type{Float128}) = Int128
+# TODO: Logically speaking, we should also make the following definitions,
+# but this would constitute type piracy under Aqua.jl rules.
+# floattype(::Type{UInt128}) = Float128
+# floattype(::Type{Int128}) = Float128
 
 # conversion
 Float128(x::Float128) = x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,27 @@
 using Test, Random
 using Quadmath
 
+@testset "fp properties" begin
+    # Test that the definitions of sign_mask, exponent_mask, significand_bits,
+    # etc. are compatible with the definitions in base/float.jl. Compare to:
+    # https://github.com/JuliaLang/julia/blob/5595d20a2877560583cd4891ce91605d10b1bb75/base/float.jl#L106
+    @test Base.significand_bits(Float128) ===
+        trailing_ones(Base.significand_mask(Float128))
+    @test Base.exponent_bits(Float128) ===
+        sizeof(Float128)*8 - Base.significand_bits(Float128) - 1
+    @test Base.exponent_bias(Float128) === Int(
+        Base.exponent_one(Float128) >> Base.significand_bits(Float128))
+    @test Base.exponent_max(Float128) ===
+        Int(Base.exponent_mask(Float128) >> Base.significand_bits(Float128)) -
+            Base.exponent_bias(Float128) - 1
+    @test Base.exponent_raw_max(Float128) === Int(
+        Base.exponent_mask(Float128) >> Base.significand_bits(Float128))
+    @test Base.uinttype(Float128) === UInt128
+    @test Base.inttype(Float128) === Int128
+    @test Base.floattype(UInt128) === Float128
+    @test Base.floattype(Int128) === Float128
+end
+
 @testset "fp decomp" begin
     y = Float128(2.0)
     x,n = frexp(y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,8 +18,6 @@ using Quadmath
         Base.exponent_mask(Float128) >> Base.significand_bits(Float128))
     @test Base.uinttype(Float128) === UInt128
     @test Base.inttype(Float128) === Int128
-    @test Base.floattype(UInt128) === Float128
-    @test Base.floattype(Int128) === Float128
 end
 
 @testset "fp decomp" begin


### PR DESCRIPTION
Fixes #81. I've also added tests for the new methods.