### PR TITLE
Fix `[compat]` entries for stdlibs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,11 +11,11 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [compat]
 Aqua = "0.6"
 Compat = "4.4"
-Printf = "1.6"
-Random = "1.6"
+Printf = "<0.0.1, 1"
+Random = "<0.0.1, 1"
 Requires = "1.0"
 SpecialFunctions = "2.0"
-Test = "1.6"
+Test = "<0.0.1, 1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
See https://discourse.julialang.org/t/why-random-jl-is-fixed-to-version-0-0-0/105957/2

This is a follow-up to #70.