### PR TITLE
compat: Allow Aqua 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 QuadmathSpecialFunctionsExt = ["SpecialFunctions"]
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.6, 0.8"
 Compat = "4.4"
 Printf = "<0.0.1, 1"
 Random = "<0.0.1, 1"


### PR DESCRIPTION
Aqua 0.6.7's type-piracy/ambiguity detection produces false positives under JuliaLang/julia#61915 (the TypeEq refactor), flagging the package's own inner constructors as piracy because Type{T} is now a TypeEq kind. Aqua 0.8.15 fixes this (it uses Base.isType). Allow Aqua 0.8 so tests pass on recent Julia.

This change was made with the assistance of generative AI (Claude Code).