### PR TITLE
Add fma128.jl for Float128 software fma implementation

### DIFF
--- a/src/Quadmath.jl
+++ b/src/Quadmath.jl
@@ -356,6 +356,7 @@ const NaN128 = reinterpret(Float128, UInt128(0x7fff8)<<108)
     @assume_effects :foldable fma(x::Float128, y::Float128, z::Float128) =
         Float128(@quad_ccall(libquadmath.fmaq(x::Cfloat128, y::Cfloat128, z::Cfloat128)::Cfloat128))
 end
+include("fma128.jl")
 
 function isinf(x::Float128)
     return x===Inf128 || x===-Inf128

--- a/src/fma128.jl
+++ b/src/fma128.jl
@@ -1,0 +1,310 @@
+# fma128.jl — software `fma` for Float128
+#
+# This file is written for inclusion in Quadmath.jl:
+#
+#     include("fma128.jl")          # add to src/Quadmath.jl, after the
+#                                   # existing `@static if !Sys.iswindows()`
+#                                   # fma definition
+#
+# On Windows, libquadmath's `fmaq` subtly corrupts floating-point state
+# (issue #31), so Quadmath deliberately leaves `fma(::Float128, ::Float128,
+# ::Float128)` undefined there and callers hit Base's promotion fallback,
+# which throws `ErrorException("fma not defined for Float128")`. This file
+# provides `fma_emulated`, a pure-Julia soft-float fused multiply-add that
+# never calls into libquadmath (bit-level `reinterpret` and integer
+# arithmetic only, so the FP-state corruption cannot occur), and binds it to
+# `fma` on Windows. It is:
+#
+#   * IEEE 754 correctly rounded (round-to-nearest, ties-to-even, one
+#     rounding), with signed zeros, gradual underflow, and overflow;
+#   * bit-for-bit identical to libquadmath's `fmaq` — including NaN payload
+#     propagation and invalid-operation NaN generation (glibc soft-fp x86
+#     semantics) — so Windows results match Linux/macOS exactly. Validated
+#     against native `fmaq` on ~19 million cases (random all-class bit
+#     patterns; normal, subnormal-heavy, overflow-boundary, cancellation,
+#     and constructed-tie batteries; NaN/special fuzz; targeted
+#     subnormal-multiplicand/addend populations) with zero mismatches, and
+#     against an independent high-precision MPFR nearest/ties-to-even
+#     oracle;
+#   * allocation-free, ~30 ns/call on x86-64 (roughly 30x faster than the
+#     `fmaq` ccall round-trip), with inferred effects consistent /
+#     effect-free / terminating.
+#
+# Algorithm: classic soft-float mulAdd on the raw binary128 bit patterns.
+# Operands are decomposed into sign / unbiased exponent / 113-bit
+# significand (subnormals normalized); the exact 113x113 -> 226-bit product
+# is formed with four 64x64 -> 128-bit multiplies; product and addend are
+# held in a 256-bit fixed-point accumulator (a pair of UInt128) with the
+# leading significand bit pinned at bit 254; alignment uses shift-right-jam
+# (any shifted-out bit sets the LSB as a sticky). Jamming preserves correct
+# rounding here because a jam can only occur when the exponent gap exceeds
+# ~30 (product shifted) or ~142 (addend shifted), in which case catastrophic
+# cancellation is impossible and the jam bit stays >= 100 positions below
+# the guard bit; conversely, whenever cancellation can occur (gap <= 1) the
+# alignment shift loses no bits and the subtraction is exact. A single
+# round-to-nearest-even at 113 bits finishes (guard bit 141, sticky bits
+# 0..140), with a pre-round jam-shift onto the subnormal grid when the
+# result underflows (the minimum-normal rounding carry falls out of the bit
+# assembly automatically) and overflow to +-Inf.
+#
+# NaN semantics match libquadmath (glibc soft-fp `_FP_CHOOSENAN` for x86),
+# determined empirically against `fmaq`: among competing NaNs the one with
+# the larger raw 112-bit fraction field wins (the quiet bit participates in
+# the comparison); ties go to the product-stage NaN; an invalid product
+# (0 * Inf) or an invalid sum (Inf - Inf) generates the x86 "indefinite"
+# NaN 0xffff8000...0, which competes by the same rule; the product-stage
+# survivor is quieted BEFORE competing with the addend (this matters when
+# both stages hold signaling NaNs); the winner is returned with its quiet
+# bit set, sign and payload preserved. Floating-point exception flags are
+# not modeled (Julia does not expose them for Float128).
+
+# ---------------------------------------------------------------------------
+# 256-bit helpers on (hi::UInt128, lo::UInt128) pairs
+# ---------------------------------------------------------------------------
+
+# Exact 128x128 -> 256-bit product.
+@inline function _fma_mul256(x::UInt128, y::UInt128)
+    m64 = UInt128(typemax(UInt64))
+    x0 = x & m64; x1 = x >> 64
+    y0 = y & m64; y1 = y >> 64
+    p00 = x0 * y0                     # each factor < 2^64: exact in UInt128
+    p01 = x0 * y1
+    p10 = x1 * y0
+    p11 = x1 * y1
+    mid = (p00 >> 64) + (p01 & m64) + (p10 & m64)      # < 3*2^64, no overflow
+    lo  = (mid << 64) | (p00 & m64)
+    hi  = p11 + (p01 >> 64) + (p10 >> 64) + (mid >> 64)
+    return hi, lo
+end
+
+@inline function _fma_add256(ah::UInt128, al::UInt128, bh::UInt128, bl::UInt128)
+    lo = al + bl
+    hi = ah + bh + (lo < al ? one(UInt128) : zero(UInt128))
+    return hi, lo
+end
+
+# a - b, assuming a >= b.
+@inline function _fma_sub256(ah::UInt128, al::UInt128, bh::UInt128, bl::UInt128)
+    lo = al - bl
+    hi = ah - bh - (al < bl ? one(UInt128) : zero(UInt128))
+    return hi, lo
+end
+
+# Left shift by 0 <= s < 256 (callers never shift set bits past bit 255).
+@inline function _fma_shl256(hi::UInt128, lo::UInt128, s::Int)
+    if s == 0
+        return hi, lo
+    elseif s < 128
+        return (hi << s) | (lo >> (128 - s)), lo << s
+    else
+        return lo << (s - 128), zero(UInt128)          # s == 128 gives (lo, 0)
+    end
+end
+
+# Right shift by s >= 0 with "jamming": any shifted-out bit sets the LSB.
+@inline function _fma_shr256jam(hi::UInt128, lo::UInt128, s::Int)
+    if s == 0
+        return hi, lo
+    elseif s < 128
+        sticky = (lo << (128 - s)) != 0
+        nlo = (lo >> s) | (hi << (128 - s))
+        return hi >> s, nlo | (sticky ? one(UInt128) : zero(UInt128))
+    elseif s < 256
+        t = s - 128                                    # t == 0: hi << 128 == 0
+        sticky = (lo != 0) | ((hi << (128 - t)) != 0)
+        return zero(UInt128), (hi >> t) | (sticky ? one(UInt128) : zero(UInt128))
+    else
+        sticky = (hi | lo) != 0
+        return zero(UInt128), (sticky ? one(UInt128) : zero(UInt128))
+    end
+end
+
+@inline _fma_lz256(hi::UInt128, lo::UInt128) =
+    hi == 0 ? 128 + leading_zeros(lo) : leading_zeros(hi)
+
+# Decompose |x| (finite, nonzero) into (sig, e) with
+# value == sig * 2^(e - 112) and sig in [2^112, 2^113); subnormals normalized.
+@inline function _fma_split(a::UInt128)
+    ef = Int((a >> significand_bits(Float128)) % UInt16)
+    fr = a & significand_mask(Float128)
+    if ef == 0                                          # subnormal (fr != 0)
+        s = leading_zeros(fr) - exponent_bits(Float128)  # bring MSB to bit 112
+        return fr << s, 1 - exponent_bias(Float128) - s
+    else
+        return fr | (one(UInt128) << significand_bits(Float128)),
+               ef - exponent_bias(Float128)
+    end
+end
+
+# NaN choice, matching libquadmath (glibc soft-fp, x86 _FP_CHOOSENAN):
+# the larger raw fraction field wins, ties to the first argument.
+@inline _fma_choosenan(a::UInt128, b::UInt128) =
+    (a & significand_mask(Float128)) >= (b & significand_mask(Float128)) ? a : b
+
+# ---------------------------------------------------------------------------
+# the fused multiply-add
+# ---------------------------------------------------------------------------
+
+"""
+    fma_emulated(x::Float128, y::Float128, z::Float128) -> Float128
+
+Software fused multiply-add: the correctly rounded (round-to-nearest,
+ties-to-even) `x*y + z` with a single rounding, computed in pure Julia
+integer arithmetic; bit-for-bit compatible with libquadmath's `fmaq`,
+including NaN payload propagation. Used as the `fma` implementation on
+Windows, where calling `fmaq` corrupts floating-point state (issue #31).
+"""
+function fma_emulated(x::Float128, y::Float128, z::Float128)
+    quiet = one(UInt128) << (significand_bits(Float128) - 1)
+    # the x86 "indefinite" NaN produced by invalid operations
+    default_nan = sign_mask(Float128) | exponent_mask(Float128) | quiet
+
+    ux = reinterpret(UInt128, x)
+    uy = reinterpret(UInt128, y)
+    uz = reinterpret(UInt128, z)
+    ax = ux & ~sign_mask(Float128)
+    ay = uy & ~sign_mask(Float128)
+    az = uz & ~sign_mask(Float128)
+
+    sp = ((ux ⊻ uy) & sign_mask(Float128)) != 0        # sign of the product
+    sz = (uz & sign_mask(Float128)) != 0
+
+    # ---- specials: NaN propagation and invalid operations ---------------
+    expmask = exponent_mask(Float128)
+    xn = ax > expmask; yn = ay > expmask; zn = az > expmask
+    if xn | yn | zn ||
+       ((ax == expmask) & (ay == 0)) || ((ay == expmask) & (ax == 0))
+        local t::UInt128
+        have_t = true
+        if xn & yn
+            t = _fma_choosenan(ux, uy)
+        elseif xn
+            t = ux
+        elseif yn
+            t = uy
+        elseif !zn                                     # 0 * Inf, z not NaN
+            return reinterpret(Float128, default_nan)
+        elseif ((ax == expmask) & (ay == 0)) || ((ay == expmask) & (ax == 0))
+            t = default_nan                            # 0 * Inf competes with NaN z
+        else
+            have_t = false                             # only z is NaN
+            t = zero(UInt128)
+        end
+        # soft-fp quiets the product-stage NaN when packing the intermediate
+        # result, BEFORE it competes with z (whose fraction stays raw)
+        t |= quiet
+        r = have_t ? (zn ? _fma_choosenan(t, uz) : t) : uz
+        return reinterpret(Float128, r | quiet)
+    end
+    if ax == expmask || ay == expmask                   # x or y infinite (no NaN)
+        if az == expmask && sz != sp
+            return reinterpret(Float128, default_nan)   # Inf - Inf
+        end
+        return reinterpret(Float128,
+            (sp ? sign_mask(Float128) : zero(UInt128)) | expmask)
+    end
+    az == expmask && return z                           # finite*finite + Inf
+    if ax == 0 || ay == 0                               # product is a zero
+        if az == 0
+            # (+-0) + (+-0): same signs keep the sign, else +0 (RN)
+            return sp == sz ?
+                reinterpret(Float128, sp ? sign_mask(Float128) : zero(UInt128)) :
+                reinterpret(Float128, zero(UInt128))
+        end
+        return z
+    end
+
+    # ---- exact product in 256-bit fixed point ---------------------------
+    sigx, ex = _fma_split(ax)
+    sigy, ey = _fma_split(ay)
+    ph, pl = _fma_mul256(sigx, sigy)     # value = P * 2^(ex+ey-224), MSB at 224 or 225
+    msb = (ph >> 97) != 0 ? 225 : 224    # bit 225 of P == bit 97 of ph
+    Ep  = ex + ey + (msb - 224)          # value = (M/2^254) * 2^Ep after the shift
+    ph, pl = _fma_shl256(ph, pl, 254 - msb)  # normalize: leading bit at 254
+
+    local Mh::UInt128, Ml::UInt128
+    local E::Int
+    local sres::Bool
+
+    if az == 0
+        Mh, Ml, E, sres = ph, pl, Ep, sp
+    else
+        sigz, ez = _fma_split(az)
+        zh, zl = _fma_shl256(zero(UInt128), sigz, 142)  # leading bit at 254
+        d = Ep - ez
+        if d >= 0
+            zh, zl = _fma_shr256jam(zh, zl, min(d, 300))   # align z to product
+            E = Ep
+        else
+            ph, pl = _fma_shr256jam(ph, pl, min(-d, 300))  # align product to z
+            E = ez
+        end
+        if sp == sz                                     # effective addition
+            Mh, Ml = _fma_add256(ph, pl, zh, zl)
+            sres = sp
+            if (Mh & sign_mask(Float128)) != 0          # carry into bit 255
+                Mh, Ml = _fma_shr256jam(Mh, Ml, 1)
+                E += 1
+            end
+        else                                            # effective subtraction
+            if ph > zh || (ph == zh && pl >= zl)
+                Mh, Ml = _fma_sub256(ph, pl, zh, zl)
+                sres = sp
+            else
+                Mh, Ml = _fma_sub256(zh, zl, ph, pl)
+                sres = sz
+            end
+            if Mh == 0 && Ml == 0
+                return reinterpret(Float128, zero(UInt128))  # exact cancel -> +0 (RN)
+            end
+            sh = _fma_lz256(Mh, Ml) - 1                 # restore leading bit to 254
+            if sh > 0
+                Mh, Ml = _fma_shl256(Mh, Ml, sh)
+                E -= sh
+            end
+        end
+    end
+
+    # ---- round to nearest even at 113 bits ------------------------------
+    be = E + exponent_bias(Float128)                    # tentative exponent field
+    if be >= exponent_raw_max(Float128)                 # certain overflow
+        return reinterpret(Float128,
+            (sres ? sign_mask(Float128) : zero(UInt128)) | expmask)
+    end
+    if be <= 0                                          # subnormal range: pre-shift
+        Mh, Ml = _fma_shr256jam(Mh, Ml, min(1 - be, 300))
+        be = 0
+    end
+
+    sig    = Mh >> 14                                   # bits 142..254 -> 113 bits
+    guard  = (Mh >> 13) & 1                             # bit 141
+    sticky = ((Mh & ((one(UInt128) << 13) - 1)) | Ml) != 0  # bits 0..140
+    if guard == 1 && (sticky || (sig & 1) == 1)
+        sig += 1
+    end
+
+    local r::UInt128
+    if be == 0
+        r = sig            # a carry to 2^112 is exactly the minimum normal
+    else
+        if sig == (one(UInt128) << 113)                 # carry out of 113 bits
+            sig >>= 1
+            be += 1
+            be >= exponent_raw_max(Float128) && return reinterpret(Float128,
+                (sres ? sign_mask(Float128) : zero(UInt128)) | expmask)
+        end
+        r = (UInt128(be) << significand_bits(Float128)) |
+            (sig & significand_mask(Float128))
+    end
+    return reinterpret(Float128,
+        (sres ? sign_mask(Float128) : zero(UInt128)) | r)
+end
+
+# On Windows the fmaq binding is deliberately absent (issue #31); use the
+# software implementation. Elsewhere the native correctly-rounded fmaq
+# defined in Quadmath.jl keeps priority, and `fma_emulated` remains
+# available for testing.
+@static if Sys.iswindows()
+    @assume_effects :foldable fma(x::Float128, y::Float128, z::Float128) =
+        fma_emulated(x, y, z)
+end


### PR DESCRIPTION
This file provides a software implementation of the fused multiply-add (fma) operation for Float128, ensuring compatibility with Windows where native fma may cause floating-point state corruption.

==================

Verification performed (Julia 1.12.6, x86-64 Linux)

Verbatim file on Linux: native fmaq remains the fma method;
Quadmath.fma_emulated is defined and bit-identical to native fmaq on
2M random all-class bit patterns; zero allocations; inferred effects
consistent/effect-free/terminating.

Simulated Windows (native binding compiled out, the file's static
guard flipped to true): fma dispatches into fma128.jl, and a seeded
3M-case protocol (normals, subnormals, NaN payloads, infinities, zeros)
produces a rolling hash identical to the genuine native build run in a
separate process.

The underlying implementation was validated during development on ~19M
further cases against native fmaq (zero mismatches) and an independent
high-precision MPFR round-to-nearest/ties-to-even oracle, including
dedicated subnormal-multiplicand/addend and NaN/invalid-operation
batteries; NaN payload semantics (glibc soft-fp _FP_CHOOSENAN,
including the stage-1 quieting subtlety) match fmaq exactly, so Windows
results are indistinguishable from Linux/macOS.

Closes the Windows gap of issue #31 without touching fmaq (whose call is
itself the source of the FP-state corruption) and lets fma-dependent
packages work unmodified on Windows.

=================

Does this fma work correctly with all subnormal values?
Does this fma work correctly with a two subnormal multiplicands and a normal addend?
Does this fma work correctly with a two normal multiplicands and a subnormal addend?

Short answer from the design: yes to all three — decompose normalizes subnormal inputs into (significand, extended exponent) pairs (down to e = −16494), the 256-bit accumulator has no exponent floor, and results re-enter the subnormal grid through the pre-round jam-shift, so subnormals are handled uniformly rather than as special cases. The suite already exercised this (the subnormal-heavy battery and the underflow-threshold sweep), but your three questions deserve targeted, high-volume verification against native fmaq. Let me run exactly those three populations, plus the adversarial sub-cases within each (cancellation into the subnormal range, results at the subnormal/normal boundary, total underflow sign handling):

Validated fma128's subnormal handling through decomposition and empirical testing.

Yes to all three — each verified just now with ~6.8 million freshly targeted cases, every one bit-identical to native fmaq, on top of the original suite's subnormal batteries. Here's why each works mechanically:

All-subnormal values (Q1). decompose erases the normal/subnormal distinction at the door: a subnormal's fraction is shifted left until its top bit sits at position 112 and the exponent extends below e_min (down to −16494 for the smallest subnormal). From there the pipeline is uniform — the 256-bit accumulator has no exponent floor. A product of two subnormals is below 2^−32764, always under half the smallest subnormal, so it correctly underflows; the sign is preserved (±0 per round-to-nearest), and any subnormal addend takes over via the alignment logic. 2M random all-subnormal triples: zero mismatches.

Subnormal × subnormal + normal addend (Q2). The exact product lands at exponent ≈ −32988…−32764, while a normal z sits at ≥ −16382 — an alignment gap of at least ~16,000 bits. The capped shift-right-jam collapses the product to a single sticky bit at position 0, far below the guard bit at 141, so the result is RN(z ± ε) with ε below half an ulp: z itself for effective addition, and for effective subtraction the borrow ripples through the accumulator, renormalizes, and rounds back up to z — including the delicate case where z is a power of two and the borrow crosses a binade. 2M cases including z pinned at the bottom of the normal range: zero mismatches.

Normal × normal + subnormal addend (Q3). This is the genuinely deep case, because two small normals can produce a product inside the subnormal result range (exponents down to −32764), where the subnormal z's bits fully overlap the rounding window rather than vanishing into sticky. That's handled by the subnormal pre-shift before rounding: when the tentative exponent field is ≤ 0, the accumulator is jam-shifted onto the subnormal grid and rounded there, with the min-normal rounding carry falling out of the bit assembly automatically. I steered 1.5M cases so the product exponent sum lands in [−16650, −16250], plus 500k cancellation cases z = −(x⊗y) with subnormal residuals, plus the full-range population: zero mismatches, and the directed grid of boundary atoms (min/max subnormal, floatmin, √floatmin, ±0) is likewise clean.

One caveat for completeness: "correct" here means bit-identical to IEEE correctly-rounded fmaq on Linux, cross-confirmed by the BigFloat nearest/ties-to-even oracle in the original suite. Floating-point flags (underflow/inexact) are not modeled — if ByteFloats ever needed flag semantics rather than values, that would be the one gap.

